### PR TITLE
Support for Grimy's Loot Mod (EXPERIMENTAL)

### DIFF
--- a/Random Weapon Nickname Button/Src/RandomWeaponNameButton/Classes/RandomWeaponNameButton.uc
+++ b/Random Weapon Nickname Button/Src/RandomWeaponNameButton/Classes/RandomWeaponNameButton.uc
@@ -26,10 +26,17 @@ event OnInit(UIScreen Screen)
 	local string		strWeaponNickNameTooltip;
 	local string		strNewNickName;
 
-	WeaponModScreen = UIArmory_WeaponUpgrade(Screen);
+	/*
+		Check whether the screen calling us is either of the target
+		type or one of the target type's descendants.
 
-	if (WeaponModScreen == none)
+		This will (hopefully) allow the mod to support Grimy's
+		Loot Mod.
+	*/
+	if ( !(Screen.isA('UIArmory_WeaponUpgrade')) )
 		return;
+
+	WeaponModScreen = UIArmory_WeaponUpgrade(Screen);
 
 	m_strGeneratedNickNotSupported = "Can't generate name for this weapon.";
 
@@ -82,5 +89,5 @@ simulated function GenerateRandomWeaponName(UIButton Button)
 
 defaultproperties
 {
-	ScreenClass = class'UIArmory_WeaponUpgrade';
+	ScreenClass = none;
 }


### PR DESCRIPTION
Under the guidance of /dev/null, my mod will now hopefully support Grimy's Loot Mod. It _seems_ to (I've loaded in with my mod + Grimy's + ModEverything and my button now loads in and works where before it didn't) but it's a really big mod and would take me a LONG time to test on my own...so it's "test in production" as it were.

It seems safe; it's a very simple change. But I'm annotating it as experimental and marked the release before this with a "stable" tag, juuuust incase.
